### PR TITLE
Plugin compatibility for sonar version 7.7 and cmd timeout annotate parameterizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SonarQube Jazz RTC SCM Plugin
 This plugin implements SCM dependent features of SonarQube for [Jazz RTC](https://jazz.net/library/LearnItem.jsp?href=content/docs/rtc1.0-capabilities/scm.html) projects.
 
 ## Usage
-This provider is a wrapper around 'lscm' command line utility. You need to have 'lscm' in the PATH.
+This provider is a wrapper around 'fec' command line utility. You need to have 'fec' in the PATH.
 
 Auto-detection will works if there is a .jazz5 folder in the project root directory. Otherwise you can force the provider using -Dsonar.scm.provider=jazz.
 
@@ -16,7 +16,8 @@ You can also configure some optional properties:
 | --- | ----------- |
 | sonar.jazzrtc.username | Username to be used for Jazz RTC authentication |
 | sonar.jazzrtc.password.secured | Password to be used for Jazz RTC authentication |
+| sonar.jazzrtc.cmd.timeout | Timeout to be used for Jazz RTC Annotate command |
 
 ## Known Limitations
-* Blame is not executed in parallel since it is not supported by lscm annotate.
-* 'lscm' annotate returns information from server for the given file in latest revision (whatever is the status of your local workspace).
+* Blame is not executed in parallel since it is not supported by fec annotate.
+* 'fec' annotate returns information from server for the given file in latest revision (whatever is the status of your local workspace).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.sonarsource.scm.jazzrtc</groupId>
 	<artifactId>sonar-scm-jazzrtc-plugin</artifactId>
 	<name>SonarQube :: Plugins :: SCM :: Jazz RTC</name>
-	<version>1.2-SNAPSHOT</version>
+	<version>2.0-SNAPSHOT</version>
 	<packaging>sonar-plugin</packaging>
 	<description>Jazz Rational Team Concert SCM Provider.</description>
 	<url>http://redirect.sonarsource.com/plugins/scmjazzrtc.html</url>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
 		<sonar.pluginName>Jazz RTC</sonar.pluginName>
 		<sonar.pluginClass>org.sonar.plugins.scm.jazzrtc.JazzRtcPlugin</sonar.pluginClass>
 		<gitRepositoryName>sonar-scm-jazzrtc</gitRepositoryName>
+		<jdk.version>1.7</jdk.version>
+
 	</properties>
 
 	<dependencies>
@@ -93,5 +95,64 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+
+			<!-- download source code in Eclipse, best practice -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-eclipse-plugin</artifactId>
+				<version>2.9</version>
+				<configuration>
+					<downloadSources>true</downloadSources>
+					<downloadJavadocs>false</downloadJavadocs>
+				</configuration>
+			</plugin>
+
+			<!-- Set a compiler level -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
+				</configuration>
+			</plugin>
+
+			<!-- Maven Assembly Plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>2.4.1</version>
+				<configuration>
+					<!-- get all project dependencies -->
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+
+					<!-- MainClass in mainfest make a executable jar -->
+					<archive>
+						<manifest>
+							<mainClass>org.sonar.plugins.scm.jazzrtc.JazzRtcPlugin</mainClass>
+						</manifest>
+					</archive>
+
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id>
+						<!-- bind to the packaging phase -->
+						<phase>verify</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+		</plugins>
+	</build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,95 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.sonarsource.parent</groupId>
-    <artifactId>parent</artifactId>
-    <version>31</version>
-    <relativePath />
-  </parent>
-  <groupId>org.sonarsource.scm.jazzrtc</groupId>
-  <artifactId>sonar-scm-jazzrtc-plugin</artifactId>
-  <name>SonarQube :: Plugins :: SCM :: Jazz RTC</name>
-  <version>1.2-SNAPSHOT</version>
-  <packaging>sonar-plugin</packaging>
-  <description>Jazz Rational Team Concert SCM Provider.</description>
-  <url>http://redirect.sonarsource.com/plugins/scmjazzrtc.html</url>
-  <inceptionYear>2014</inceptionYear>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.sonarsource.parent</groupId>
+		<artifactId>parent</artifactId>
+		<version>31</version>
+		<relativePath />
+	</parent>
+	<groupId>org.sonarsource.scm.jazzrtc</groupId>
+	<artifactId>sonar-scm-jazzrtc-plugin</artifactId>
+	<name>SonarQube :: Plugins :: SCM :: Jazz RTC</name>
+	<version>1.2-SNAPSHOT</version>
+	<packaging>sonar-plugin</packaging>
+	<description>Jazz Rational Team Concert SCM Provider.</description>
+	<url>http://redirect.sonarsource.com/plugins/scmjazzrtc.html</url>
+	<inceptionYear>2014</inceptionYear>
 
-  <licenses>
-    <license>
-      <name>GNU LGPL 3</name>
-      <url>http://www.gnu.org/licenses/lgpl.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+	<licenses>
+		<license>
+			<name>GNU LGPL 3</name>
+			<url>http://www.gnu.org/licenses/lgpl.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
-  <developers>
-    <developer>
-      <id>henryju</id>
-      <name>Julien Henry</name>
-      <timezone>+1</timezone>
-    </developer>
-  </developers>
+	<developers>
+		<developer>
+			<id>henryju</id>
+			<name>Julien Henry</name>
+			<timezone>+1</timezone>
+		</developer>
+	</developers>
 
-  <scm>
-    <connection>scm:git:git@github.com:SonarQubeCommunity/sonar-scm-jazzrtc.git</connection>
-    <developerConnection>scm:git:git@github.com:SonarQubeCommunity/sonar-scm-jazzrtc.git</developerConnection>
-    <url>https://github.com/SonarQubeCommunity/sonar-scm-jazzrtc</url>
-    <tag>HEAD</tag>
-  </scm>
-  
-  <issueManagement>
-    <system>GitHub Issues</system>
-    <url>https://github.com/SonarQubeCommunity/sonar-scm-jazzrtc/issues</url>
-  </issueManagement>
+	<scm>
+		<connection>scm:git:git@github.com:SonarQubeCommunity/sonar-scm-jazzrtc.git</connection>
+		<developerConnection>scm:git:git@github.com:SonarQubeCommunity/sonar-scm-jazzrtc.git</developerConnection>
+		<url>https://github.com/SonarQubeCommunity/sonar-scm-jazzrtc</url>
+		<tag>HEAD</tag>
+	</scm>
 
-  <properties>
-    <sonar.buildVersion>5.0</sonar.buildVersion>
-    <sonar.pluginName>Jazz RTC</sonar.pluginName>
-    <sonar.pluginClass>org.sonar.plugins.scm.jazzrtc.JazzRtcPlugin</sonar.pluginClass>
-    <gitRepositoryName>sonar-scm-jazzrtc</gitRepositoryName>
-  </properties>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/SonarQubeCommunity/sonar-scm-jazzrtc/issues</url>
+	</issueManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>2.0.3</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.sonar</groupId>
-      <artifactId>sonar-plugin-api</artifactId>
-      <version>${sonar.buildVersion}</version>
-      <scope>provided</scope>
-    </dependency>
+	<properties>
+		<sonar.buildVersion>5.0</sonar.buildVersion>
+		<sonar.pluginName>Jazz RTC</sonar.pluginName>
+		<sonar.pluginClass>org.sonar.plugins.scm.jazzrtc.JazzRtcPlugin</sonar.pluginClass>
+		<gitRepositoryName>sonar-scm-jazzrtc</gitRepositoryName>
+	</properties>
 
-    <!-- unit tests -->
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>1.7.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.sonar</groupId>
-      <artifactId>sonar-testing-harness</artifactId>
-      <version>${sonar.buildVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.1.3</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>2.0.3</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.sonar</groupId>
+			<artifactId>sonar-plugin-api</artifactId>
+			<version>${sonar.buildVersion}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- unit tests -->
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>1.7.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.sonar</groupId>
+			<artifactId>sonar-testing-harness</artifactId>
+			<version>${sonar.buildVersion}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.1.3</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.sonarsource.scm.jazzrtc</groupId>
 	<artifactId>sonar-scm-jazzrtc-plugin</artifactId>
 	<name>SonarQube :: Plugins :: SCM :: Jazz RTC</name>
-	<version>2.0-SNAPSHOT</version>
+	<version>2.0</version>
 	<packaging>sonar-plugin</packaging>
 	<description>Jazz Rational Team Concert SCM Provider.</description>
 	<url>http://redirect.sonarsource.com/plugins/scmjazzrtc.html</url>

--- a/pom.xml
+++ b/pom.xml
@@ -47,27 +47,35 @@
 	</issueManagement>
 
 	<properties>
-		<sonar.buildVersion>5.0</sonar.buildVersion>
+		<sonar.buildVersion>5.1</sonar.buildVersion>
 		<sonar.pluginName>Jazz RTC</sonar.pluginName>
 		<sonar.pluginClass>org.sonar.plugins.scm.jazzrtc.JazzRtcPlugin</sonar.pluginClass>
 		<gitRepositoryName>sonar-scm-jazzrtc</gitRepositoryName>
-		<jdk.version>1.7</jdk.version>
-
 	</properties>
 
 	<dependencies>
 		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
-			<version>2.0.3</version>
-			<scope>provided</scope>
+			<groupId>org.easytesting</groupId>
+			<artifactId>fest-assert</artifactId>
+			<version>1.4</version>
+			<scope>test</scope>
 		</dependency>
+
+
+
 		<dependency>
 			<groupId>org.codehaus.sonar</groupId>
 			<artifactId>sonar-plugin-api</artifactId>
 			<version>${sonar.buildVersion}</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.26</version>
+		</dependency>
+
 
 		<!-- unit tests -->
 		<dependency>
@@ -96,63 +104,5 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-
-			<!-- download source code in Eclipse, best practice -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-eclipse-plugin</artifactId>
-				<version>2.9</version>
-				<configuration>
-					<downloadSources>true</downloadSources>
-					<downloadJavadocs>false</downloadJavadocs>
-				</configuration>
-			</plugin>
-
-			<!-- Set a compiler level -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>${jdk.version}</source>
-					<target>${jdk.version}</target>
-				</configuration>
-			</plugin>
-
-			<!-- Maven Assembly Plugin -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4.1</version>
-				<configuration>
-					<!-- get all project dependencies -->
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-
-					<!-- MainClass in mainfest make a executable jar -->
-					<archive>
-						<manifest>
-							<mainClass>org.sonar.plugins.scm.jazzrtc.JazzRtcPlugin</mainClass>
-						</manifest>
-					</archive>
-
-				</configuration>
-				<executions>
-					<execution>
-						<id>make-assembly</id>
-						<!-- bind to the packaging phase -->
-						<phase>verify</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
-		</plugins>
-	</build>
 
 </project>

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommand.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommand.java
@@ -108,7 +108,7 @@ public class JazzRtcBlameCommand extends BlameCommand {
   }
 
   private Command createCommandLine(File workingDirectory, String filename) {
-    Command cl = Command.create("lscm");
+    Command cl = Command.create("fec");
     // SONARSCRTC-3 and SONARSCRTC-6
     if(system.isOsWindows()) {
       cl.setNewShell(true);

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommand.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommand.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.plugins.scm.jazzrtc;
 
-import org.sonar.api.utils.System2;
-
 import java.io.File;
 import java.util.List;
 
@@ -31,6 +29,7 @@ import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.scm.BlameCommand;
 import org.sonar.api.batch.scm.BlameLine;
+import org.sonar.api.utils.System2;
 import org.sonar.api.utils.command.Command;
 import org.sonar.api.utils.command.CommandExecutor;
 import org.sonar.api.utils.command.StreamConsumer;

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommand.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommand.java
@@ -20,9 +20,9 @@
 package org.sonar.plugins.scm.jazzrtc;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FileSystem;
@@ -39,7 +39,7 @@ import org.sonar.api.utils.command.TimeoutException;
 public class JazzRtcBlameCommand extends BlameCommand {
 
   private static final Logger LOG = LoggerFactory.getLogger(JazzRtcBlameCommand.class);
-  private static final int[] UNTRACKED_BLAME_RETURN_CODES = {1, 3, 30};
+  private static final List<Integer> UNTRACKED_BLAME_RETURN_CODES = Arrays.asList(1, 3, 30);
   private final CommandExecutor commandExecutor;
   private final JazzRtcConfiguration config;
   private final System2 system;
@@ -75,7 +75,8 @@ public class JazzRtcBlameCommand extends BlameCommand {
     StringStreamConsumer stderr = new StringStreamConsumer();
 
     int exitCode = execute(cl, consumer, stderr);
-    if (ArrayUtils.contains(UNTRACKED_BLAME_RETURN_CODES, exitCode)) {
+    // SONARSCRTC-13
+    if (UNTRACKED_BLAME_RETURN_CODES.contains(exitCode)) {
       LOG.debug("Skipping untracked file: {}. Annotate command exit code: {}", filename, exitCode);
       return;
     } else if (exitCode != 0) {

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
@@ -35,18 +35,18 @@ import java.util.List;
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
 public class JazzRtcConfiguration implements BatchComponent {
 
-  private static final String CATEGORY_JAZZ = "Jazz RTC";
-  private static final long CMD_TIMEOUT = 60_000;
-  public static final String USER_PROP_KEY = "sonar.jazzrtc.username";
-  public static final String PASSWORD_PROP_KEY = "sonar.jazzrtc.password.secured";
+	private static final String CATEGORY_JAZZ = "Jazz RTC";
+	public static final String CMD_TIMEOUT = "sonar.jazzrtc.cmd.timeout";
+	public static final String USER_PROP_KEY = "sonar.jazzrtc.username";
+	public static final String PASSWORD_PROP_KEY = "sonar.jazzrtc.password.secured";
 
-  private final Settings settings;
+	private final Settings settings;
 
-  public JazzRtcConfiguration(Settings settings) {
-    this.settings = settings;
-  }
+	public JazzRtcConfiguration(Settings settings) {
+		this.settings = settings;
+	}
 
-  public static List<PropertyDefinition> getProperties() {
+	public static List<PropertyDefinition> getProperties() {
     return ImmutableList.of(
       PropertyDefinition.builder(USER_PROP_KEY)
         .name("Username")
@@ -65,21 +65,36 @@ public class JazzRtcConfiguration implements BatchComponent {
         .category(CoreProperties.CATEGORY_SCM)
         .subCategory(CATEGORY_JAZZ)
         .index(1)
+        .build(),
+      PropertyDefinition.builder(CMD_TIMEOUT)
+        .name("CMD Timeout")
+        .description("Timeout to be used for Jazz RTC Annotate command")
+        .type(PropertyType.INTEGER)
+        .onQualifiers(Qualifiers.PROJECT)
+        .category(CoreProperties.CATEGORY_SCM)
+        .subCategory(CATEGORY_JAZZ)
+        .index(2)
         .build());
   }
 
-  @CheckForNull
-  public String username() {
-    return settings.getString(USER_PROP_KEY);
-  }
+	@CheckForNull
+	public String username() {
+		return settings.getString(USER_PROP_KEY);
+	}
 
-  @CheckForNull
-  public String password() {
-    return settings.getString(PASSWORD_PROP_KEY);
-  }
-  
-  public long commandTimeout() {
-    return CMD_TIMEOUT;
-  }
+	@CheckForNull
+	public String password() {
+		return settings.getString(PASSWORD_PROP_KEY);
+	}
+
+	public long commandTimeout() {
+		long defaultCommandTimeout = 60_000;
+		int alternativeCommandTimeout = settings.getInt(CMD_TIMEOUT);
+		
+		if(alternativeCommandTimeout != 0)
+			defaultCommandTimeout = alternativeCommandTimeout;
+		
+		return defaultCommandTimeout;
+	}
 
 }

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
@@ -70,6 +70,7 @@ public class JazzRtcConfiguration implements BatchComponent {
         .name("CMD Timeout")
         .description("Timeout to be used for Jazz RTC Annotate command")
         .type(PropertyType.INTEGER)
+        .defaultValue("60000")
         .onQualifiers(Qualifiers.PROJECT)
         .category(CoreProperties.CATEGORY_SCM)
         .subCategory(CATEGORY_JAZZ)

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.scm.jazzrtc;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.CheckForNull;
@@ -65,23 +66,8 @@ public class JazzRtcConfiguration implements BatchComponent {
 				.defaultValue("60000").onQualifiers(Qualifiers.PROJECT).category(CoreProperties.CATEGORY_SCM)
 				.subCategory(CATEGORY_JAZZ).index(2).build());
 
-		return listPropertiesDefinition;
-		/*
-		 * return ImmutableList.of( PropertyDefinition.builder(USER_PROP_KEY)
-		 * .name("Username")
-		 * .description("Username to be used for Jazz RTC authentication")
-		 * .type(PropertyType.STRING) .onQualifiers(Qualifiers.PROJECT)
-		 * .category(CoreProperties.CATEGORY_SCM) .subCategory(CATEGORY_JAZZ) .index(0)
-		 * .build(), PropertyDefinition.builder(PASSWORD_PROP_KEY) .name("Password")
-		 * .description("Password to be used for Jazz RTC authentication")
-		 * .type(PropertyType.PASSWORD) .onQualifiers(Qualifiers.PROJECT)
-		 * .category(CoreProperties.CATEGORY_SCM) .subCategory(CATEGORY_JAZZ) .index(1)
-		 * .build(), PropertyDefinition.builder(CMD_TIMEOUT) .name("CMD Timeout")
-		 * .description("Timeout to be used for Jazz RTC Annotate command")
-		 * .type(PropertyType.INTEGER) .defaultValue("60000")
-		 * .onQualifiers(Qualifiers.PROJECT) .category(CoreProperties.CATEGORY_SCM)
-		 * .subCategory(CATEGORY_JAZZ) .index(2) .build());
-		 */
+		return Collections.unmodifiableList(listPropertiesDefinition);
+		
 	}
 
 	@CheckForNull

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
@@ -19,7 +19,11 @@
  */
 package org.sonar.plugins.scm.jazzrtc;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+
 import org.sonar.api.BatchComponent;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.PropertyType;
@@ -27,10 +31,6 @@ import org.sonar.api.batch.InstantiationStrategy;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.Settings;
 import org.sonar.api.resources.Qualifiers;
-
-import javax.annotation.CheckForNull;
-
-import java.util.List;
 
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
 public class JazzRtcConfiguration implements BatchComponent {
@@ -47,36 +47,42 @@ public class JazzRtcConfiguration implements BatchComponent {
 	}
 
 	public static List<PropertyDefinition> getProperties() {
-    return ImmutableList.of(
-      PropertyDefinition.builder(USER_PROP_KEY)
-        .name("Username")
-        .description("Username to be used for Jazz RTC authentication")
-        .type(PropertyType.STRING)
-        .onQualifiers(Qualifiers.PROJECT)
-        .category(CoreProperties.CATEGORY_SCM)
-        .subCategory(CATEGORY_JAZZ)
-        .index(0)
-        .build(),
-      PropertyDefinition.builder(PASSWORD_PROP_KEY)
-        .name("Password")
-        .description("Password to be used for Jazz RTC authentication")
-        .type(PropertyType.PASSWORD)
-        .onQualifiers(Qualifiers.PROJECT)
-        .category(CoreProperties.CATEGORY_SCM)
-        .subCategory(CATEGORY_JAZZ)
-        .index(1)
-        .build(),
-      PropertyDefinition.builder(CMD_TIMEOUT)
-        .name("CMD Timeout")
-        .description("Timeout to be used for Jazz RTC Annotate command")
-        .type(PropertyType.INTEGER)
-        .defaultValue("60000")
-        .onQualifiers(Qualifiers.PROJECT)
-        .category(CoreProperties.CATEGORY_SCM)
-        .subCategory(CATEGORY_JAZZ)
-        .index(2)
-        .build());
-  }
+
+		List<PropertyDefinition> listPropertiesDefinition = new ArrayList<PropertyDefinition>();
+
+		listPropertiesDefinition.add(PropertyDefinition.builder(USER_PROP_KEY).name("Username")
+				.description("Username to be used for Jazz RTC authentication").type(PropertyType.STRING)
+				.onQualifiers(Qualifiers.PROJECT).category(CoreProperties.CATEGORY_SCM).subCategory(CATEGORY_JAZZ)
+				.index(0).build());
+
+		listPropertiesDefinition.add(PropertyDefinition.builder(PASSWORD_PROP_KEY).name("Password")
+				.description("Password to be used for Jazz RTC authentication").type(PropertyType.PASSWORD)
+				.onQualifiers(Qualifiers.PROJECT).category(CoreProperties.CATEGORY_SCM).subCategory(CATEGORY_JAZZ)
+				.index(1).build());
+
+		listPropertiesDefinition.add(PropertyDefinition.builder(CMD_TIMEOUT).name("CMD Timeout")
+				.description("Timeout to be used for Jazz RTC Annotate command").type(PropertyType.INTEGER)
+				.defaultValue("60000").onQualifiers(Qualifiers.PROJECT).category(CoreProperties.CATEGORY_SCM)
+				.subCategory(CATEGORY_JAZZ).index(2).build());
+
+		return listPropertiesDefinition;
+		/*
+		 * return ImmutableList.of( PropertyDefinition.builder(USER_PROP_KEY)
+		 * .name("Username")
+		 * .description("Username to be used for Jazz RTC authentication")
+		 * .type(PropertyType.STRING) .onQualifiers(Qualifiers.PROJECT)
+		 * .category(CoreProperties.CATEGORY_SCM) .subCategory(CATEGORY_JAZZ) .index(0)
+		 * .build(), PropertyDefinition.builder(PASSWORD_PROP_KEY) .name("Password")
+		 * .description("Password to be used for Jazz RTC authentication")
+		 * .type(PropertyType.PASSWORD) .onQualifiers(Qualifiers.PROJECT)
+		 * .category(CoreProperties.CATEGORY_SCM) .subCategory(CATEGORY_JAZZ) .index(1)
+		 * .build(), PropertyDefinition.builder(CMD_TIMEOUT) .name("CMD Timeout")
+		 * .description("Timeout to be used for Jazz RTC Annotate command")
+		 * .type(PropertyType.INTEGER) .defaultValue("60000")
+		 * .onQualifiers(Qualifiers.PROJECT) .category(CoreProperties.CATEGORY_SCM)
+		 * .subCategory(CATEGORY_JAZZ) .index(2) .build());
+		 */
+	}
 
 	@CheckForNull
 	public String username() {
@@ -91,10 +97,10 @@ public class JazzRtcConfiguration implements BatchComponent {
 	public long commandTimeout() {
 		long defaultCommandTimeout = 60_000;
 		int alternativeCommandTimeout = settings.getInt(CMD_TIMEOUT);
-		
-		if(alternativeCommandTimeout != 0)
+
+		if (alternativeCommandTimeout != 0)
 			defaultCommandTimeout = alternativeCommandTimeout;
-		
+
 		return defaultCommandTimeout;
 	}
 

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcConfiguration.java
@@ -38,6 +38,7 @@ public class JazzRtcConfiguration implements BatchComponent {
 
 	private static final String CATEGORY_JAZZ = "Jazz RTC";
 	public static final String CMD_TIMEOUT = "sonar.jazzrtc.cmd.timeout";
+	public static final long CMD_DEFAULT_TIMEOUT = 60_000;
 	public static final String USER_PROP_KEY = "sonar.jazzrtc.username";
 	public static final String PASSWORD_PROP_KEY = "sonar.jazzrtc.password.secured";
 
@@ -61,6 +62,7 @@ public class JazzRtcConfiguration implements BatchComponent {
 				.onQualifiers(Qualifiers.PROJECT).category(CoreProperties.CATEGORY_SCM).subCategory(CATEGORY_JAZZ)
 				.index(1).build());
 
+		// SONARSCRTC-9
 		listPropertiesDefinition.add(PropertyDefinition.builder(CMD_TIMEOUT).name("CMD Timeout")
 				.description("Timeout to be used for Jazz RTC Annotate command").type(PropertyType.INTEGER)
 				.defaultValue("60000").onQualifiers(Qualifiers.PROJECT).category(CoreProperties.CATEGORY_SCM)
@@ -81,13 +83,12 @@ public class JazzRtcConfiguration implements BatchComponent {
 	}
 
 	public long commandTimeout() {
-		long defaultCommandTimeout = 60_000;
 		int alternativeCommandTimeout = settings.getInt(CMD_TIMEOUT);
 
 		if (alternativeCommandTimeout != 0)
-			defaultCommandTimeout = alternativeCommandTimeout;
+			return alternativeCommandTimeout;
 
-		return defaultCommandTimeout;
+		return CMD_DEFAULT_TIMEOUT;
 	}
 
 }

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPlugin.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPlugin.java
@@ -34,7 +34,6 @@ public final class JazzRtcPlugin extends SonarPlugin {
     result.add(JazzRtcScmProvider.class);
     result.add(JazzRtcBlameCommand.class);
     result.add(JazzRtcConfiguration.class);
-    
     result.addAll(JazzRtcConfiguration.getProperties());
     
     return Collections.unmodifiableList(result);

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPlugin.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPlugin.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.scm.jazzrtc;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.sonar.api.SonarPlugin;
@@ -27,15 +28,16 @@ import org.sonar.api.SonarPlugin;
 public final class JazzRtcPlugin extends SonarPlugin {
 
   @Override
-  public List getExtensions() {
-    List result = new ArrayList();
+  public List<Object> getExtensions() {
+    List<Object> result = new ArrayList<Object>();
     
     result.add(JazzRtcScmProvider.class);
     result.add(JazzRtcBlameCommand.class);
     result.add(JazzRtcConfiguration.class);
     
     result.addAll(JazzRtcConfiguration.getProperties());
-    return result;
+    
+    return Collections.unmodifiableList(result);
   }
 
 }

--- a/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPlugin.java
+++ b/src/main/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPlugin.java
@@ -19,21 +19,21 @@
  */
 package org.sonar.plugins.scm.jazzrtc;
 
-import com.google.common.collect.ImmutableList;
-import org.sonar.api.SonarPlugin;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.sonar.api.SonarPlugin;
 
 public final class JazzRtcPlugin extends SonarPlugin {
 
   @Override
   public List getExtensions() {
     List result = new ArrayList();
-    result.addAll(ImmutableList.of(
-      JazzRtcScmProvider.class,
-      JazzRtcBlameCommand.class,
-      JazzRtcConfiguration.class));
+    
+    result.add(JazzRtcScmProvider.class);
+    result.add(JazzRtcBlameCommand.class);
+    result.add(JazzRtcConfiguration.class);
+    
     result.addAll(JazzRtcConfiguration.getProperties());
     return result;
   }

--- a/src/test/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommandTest.java
+++ b/src/test/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommandTest.java
@@ -19,17 +19,29 @@
  */
 package org.sonar.plugins.scm.jazzrtc;
 
-import org.mockito.ArgumentCaptor;
-import org.sonar.api.utils.System2;
-import org.sonar.api.utils.command.TimeoutException;
-import org.mockito.MockitoAnnotations;
-import org.mockito.Mock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.sonar.api.batch.fs.InputFile;
@@ -40,24 +52,11 @@ import org.sonar.api.batch.scm.BlameCommand.BlameOutput;
 import org.sonar.api.batch.scm.BlameLine;
 import org.sonar.api.config.Settings;
 import org.sonar.api.utils.DateUtils;
+import org.sonar.api.utils.System2;
 import org.sonar.api.utils.command.Command;
 import org.sonar.api.utils.command.CommandExecutor;
 import org.sonar.api.utils.command.StreamConsumer;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import static org.mockito.Matchers.eq;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.sonar.api.utils.command.TimeoutException;
 
 public class JazzRtcBlameCommandTest {
   @Mock
@@ -86,15 +85,14 @@ public class JazzRtcBlameCommandTest {
     MockitoAnnotations.initMocks(this);
 
     baseDir = temp.newFolder();
-    fs = new DefaultFileSystem();
-    fs.setBaseDir(baseDir);
+    fs = new DefaultFileSystem(baseDir);
     when(input.fileSystem()).thenReturn(fs);
   }
 
   private DefaultInputFile createTestFile(String filePath, int numLines) throws IOException {
     File source = new File(baseDir, filePath);
     FileUtils.write(source, "sample content");
-    DefaultInputFile inputFile = new DefaultInputFile("foo", filePath).setLines(numLines).setAbsolutePath(new File(baseDir, filePath).getAbsolutePath());
+    DefaultInputFile inputFile = new DefaultInputFile("foo", filePath).setLines(numLines);
     fs.add(inputFile);
     return inputFile;
   }

--- a/src/test/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommandTest.java
+++ b/src/test/java/org/sonar/plugins/scm/jazzrtc/JazzRtcBlameCommandTest.java
@@ -227,7 +227,7 @@ public class JazzRtcBlameCommandTest {
       public Integer answer(InvocationOnMock invocation) throws Throwable {
         StreamConsumer outConsumer = (StreamConsumer) invocation.getArguments()[1];
         outConsumer.consumeLine("Problem running 'annotate':");
-        outConsumer.consumeLine("No remote versionable found for \"/tmp/b/dummy-git/src/testfile\". Try 'lscm help annotate' for more information.");
+        outConsumer.consumeLine("No remote versionable found for \"/tmp/b/dummy-git/src/testfile\". Try 'fec help annotate' for more information.");
         return 1;
       }
     });
@@ -264,7 +264,7 @@ public class JazzRtcBlameCommandTest {
   }
 
   /**
-   * Tested with <pre>lscm annotate -u invalid -P invalid pom.xml</pre>
+   * Tested with <pre>fec annotate -u invalid -P invalid pom.xml</pre>
    */
   @Test(expected = IllegalStateException.class)
   public void testInvalidCredentials() throws IOException {

--- a/src/test/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPluginTest.java
+++ b/src/test/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPluginTest.java
@@ -27,6 +27,6 @@ public class JazzRtcPluginTest {
 
   @Test
   public void getExtensions() {
-    assertThat(new JazzRtcPlugin().getExtensions()).hasSize(5);
+    assertThat(new JazzRtcPlugin().getExtensions()).hasSize(6);
   }
 }

--- a/src/test/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPluginTest.java
+++ b/src/test/java/org/sonar/plugins/scm/jazzrtc/JazzRtcPluginTest.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.plugins.scm.jazzrtc;
 
-import org.junit.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
 
 public class JazzRtcPluginTest {
 


### PR DESCRIPTION
Plugin Compatibility for sonar version 7.7;
Feature cmd editable timeout, annotate command, parameterizable field;
Change launcher 'lscm' to 'fec' ( lscm calls fec, under the table ).


